### PR TITLE
Add TensorFlow checkpoint to PyTorch converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ Forked from https://github.com/LynnHo/DCGAN-LSGAN-WGAN-WGAN-GP-Tensorflow
 
 ...
 ```
+
+### PyTorch DCGAN training
+
+We now provide a PyTorch re-implementation of the CelebA DCGAN baseline that mirrors the behaviour of `train_celeba_dcgan.py`.
+
+```
+python train_celeba_dcgan_torch.py \
+    --data-root ./data/img_align_celeba/img_align_celeba \
+    --epochs 50 \
+    --batch-size 64
+```
+
+Generated sample grids are written to `./sample_images_while_training/celeba_dcgan_torch/` and checkpoints to `./checkpoints/celeba_dcgan_torch/`. Run `python train_celeba_dcgan_torch.py --help` for the full list of configurable options.
+
+### Convert TensorFlow checkpoints to PyTorch
+
+If you have an existing TensorFlow checkpoint created by `train_celeba_dcgan.py` you can convert it into a PyTorch checkpoint
+that is compatible with `train_celeba_dcgan_torch.py` and other PyTorch utilities in this repository.
+
+```
+python convert_tf_checkpoint_to_torch.py \
+    checkpoints/celeba_dcgan/model-100000 \
+    checkpoints/celeba_dcgan_torch/model-100000.pt
+```
+
+Pass `--latent-dim` or `--channels` if you trained with non-default hyper-parameters. The converter recreates the TensorFlow
+graph defined in `models_64x64.py`, loads the weights, and transfers them into the matching modules in `models_64x64_torch.py`.
 ## Tensorboard
 ```
 tensorboard --logdir=./logs/sia/

--- a/convert_tf_checkpoint_to_torch.py
+++ b/convert_tf_checkpoint_to_torch.py
@@ -1,0 +1,177 @@
+"""Utility to convert TensorFlow DCGAN checkpoints into PyTorch format.
+
+The original project ships TensorFlow checkpoints trained with the
+``models_64x64`` DCGAN architecture.  This tool rebuilds that graph,
+loads a provided checkpoint, and translates the weights into the
+PyTorch modules defined in :mod:`models_64x64_torch` so that the weights
+can be reused with the new training and sampling scripts.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+import torch
+import numpy as np
+
+try:
+    import tensorflow as tf  # type: ignore
+except ImportError as exc:  # pragma: no cover - import guard for optional dep
+    raise SystemExit(
+        "TensorFlow is required to run this conversion script. Install tensorflow>=1.10."
+    ) from exc
+
+import models_64x64 as tf_models
+from models_64x64_torch import DCGANConfig, Discriminator, Generator
+
+
+if hasattr(tf, "compat") and hasattr(tf.compat, "v1"):
+    tf1 = tf.compat.v1
+    tf1.disable_eager_execution()
+else:  # pragma: no cover - TensorFlow 1.x fallback
+    tf1 = tf
+
+
+def _load_tensorflow_checkpoint(
+    checkpoint: str, latent_dim: int, base_channels: int
+) -> Dict[str, np.ndarray]:
+    """Restore the TensorFlow DCGAN graph and collect variable values."""
+
+    tf1.reset_default_graph()
+    z = tf1.placeholder(tf.float32, shape=[None, latent_dim], name="z")
+    x = tf1.placeholder(tf.float32, shape=[None, 64, 64, 3], name="x")
+
+    with tf1.variable_scope(tf1.get_variable_scope()):
+        tf_models.generator(z, dim=base_channels, reuse=False, training=False)
+        tf_models.discriminator(x, dim=base_channels, reuse=False, training=False)
+
+    saver = tf1.train.Saver()
+    with tf1.Session() as sess:
+        saver.restore(sess, checkpoint)
+        values = {var.name: sess.run(var) for var in tf1.global_variables()}
+    return values
+
+
+def _get_var(values: Dict[str, np.ndarray], name: str) -> np.ndarray:
+    try:
+        return values[name]
+    except KeyError as exc:
+        raise KeyError(f"TensorFlow variable '{name}' was not found in the checkpoint") from exc
+
+
+def _assign_batch_norm(
+    state_dict: Dict[str, torch.Tensor],
+    prefix: str,
+    values: Dict[str, np.ndarray],
+    tf_prefix: str,
+) -> None:
+    state_dict[f"{prefix}.weight"] = torch.from_numpy(_get_var(values, f"{tf_prefix}/gamma:0")).float()
+    state_dict[f"{prefix}.bias"] = torch.from_numpy(_get_var(values, f"{tf_prefix}/beta:0")).float()
+    state_dict[f"{prefix}.running_mean"] = torch.from_numpy(
+        _get_var(values, f"{tf_prefix}/moving_mean:0")
+    ).float()
+    state_dict[f"{prefix}.running_var"] = torch.from_numpy(
+        _get_var(values, f"{tf_prefix}/moving_variance:0")
+    ).float()
+
+
+def _transpose_filter(weights: np.ndarray) -> torch.Tensor:
+    return torch.from_numpy(weights.transpose(3, 2, 0, 1)).float()
+
+
+def _load_generator_from_tf(generator: Generator, values: Dict[str, np.ndarray]) -> None:
+    state_dict = generator.state_dict()
+
+    fc_weights = _get_var(values, "generator/flatten_fully_connected/fully_connected/weights:0")
+    state_dict["project.linear.weight"] = torch.from_numpy(fc_weights.T).float()
+    _assign_batch_norm(
+        state_dict,
+        "project.bn",
+        values,
+        "generator/flatten_fully_connected/BatchNorm",
+    )
+
+    for idx, layer_name in enumerate(["", "_1", "_2"]):
+        weight = _get_var(values, f"generator/conv2d_transpose{layer_name}/weights:0")
+        state_dict[f"upsamplers.deconv{idx + 1}.weight"] = _transpose_filter(weight)
+        _assign_batch_norm(
+            state_dict,
+            f"upsamplers.bn{idx + 1}",
+            values,
+            f"generator/conv2d_transpose{layer_name}/BatchNorm",
+        )
+
+    weight = _get_var(values, "generator/conv2d_transpose_3/weights:0")
+    state_dict["upsamplers.deconv4.weight"] = _transpose_filter(weight)
+    state_dict["upsamplers.deconv4.bias"] = torch.from_numpy(
+        _get_var(values, "generator/conv2d_transpose_3/biases:0")
+    ).float()
+
+    generator.load_state_dict(state_dict)
+
+
+def _load_discriminator_from_tf(
+    discriminator: Discriminator, values: Dict[str, np.ndarray]
+) -> None:
+    state_dict = discriminator.state_dict()
+
+    weight = _get_var(values, "discriminator/conv2d/weights:0")
+    state_dict["features.conv1.weight"] = _transpose_filter(weight)
+    state_dict["features.conv1.bias"] = torch.from_numpy(
+        _get_var(values, "discriminator/conv2d/biases:0")
+    ).float()
+
+    for idx, layer_name in enumerate(["_1", "_2", "_3"], start=2):
+        weight = _get_var(values, f"discriminator/conv2d{layer_name}/weights:0")
+        state_dict[f"features.conv{idx}.weight"] = _transpose_filter(weight)
+        _assign_batch_norm(
+            state_dict,
+            f"features.bn{idx}",
+            values,
+            f"discriminator/conv2d{layer_name}/BatchNorm",
+        )
+
+    fc_weights = _get_var(values, "discriminator/flatten_fully_connected/fully_connected/weights:0")
+    state_dict["head.weight"] = torch.from_numpy(fc_weights.T).float()
+    state_dict["head.bias"] = torch.from_numpy(
+        _get_var(values, "discriminator/flatten_fully_connected/fully_connected/biases:0")
+    ).float()
+
+    discriminator.load_state_dict(state_dict)
+
+
+def convert_checkpoint(args: argparse.Namespace) -> None:
+    values = _load_tensorflow_checkpoint(args.tf_checkpoint, args.latent_dim, args.channels)
+    config = DCGANConfig(latent_dim=args.latent_dim, base_channels=args.channels, image_channels=args.image_channels)
+
+    generator = Generator(config)
+    discriminator = Discriminator(config)
+
+    _load_generator_from_tf(generator, values)
+    _load_discriminator_from_tf(discriminator, values)
+
+    payload = {
+        "config": config.__dict__,
+        "generator": generator.state_dict(),
+        "discriminator": discriminator.state_dict(),
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(payload, output_path)
+    print(f"Saved PyTorch checkpoint to {output_path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert TensorFlow CelebA DCGAN checkpoint to PyTorch format")
+    parser.add_argument("tf_checkpoint", help="Path to the TensorFlow checkpoint (e.g. checkpoints/model-100000)")
+    parser.add_argument("output", help="Destination .pt file for the converted checkpoint")
+    parser.add_argument("--latent-dim", type=int, default=100, help="Latent dimension used during training")
+    parser.add_argument("--channels", type=int, default=64, help="Base channel width used in the model")
+    parser.add_argument("--image-channels", type=int, default=3, help="Number of image colour channels")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    convert_checkpoint(parse_args())

--- a/models_64x64_torch.py
+++ b/models_64x64_torch.py
@@ -1,0 +1,219 @@
+"""PyTorch implementation of the 64x64 generator and discriminator networks.
+
+This module mirrors the TensorFlow version in :mod:`models_64x64` but uses
+PyTorch's ``nn.Module`` classes so it can be integrated with a PyTorch
+training pipeline.  The architecture follows the standard DCGAN design that
+is used throughout the original project.  It intentionally keeps the API
+minimal so the modules can be reused in standalone scripts or notebooks.
+"""
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+
+
+@dataclass
+class DCGANConfig:
+    """Configuration describing the DCGAN model layout."""
+
+    latent_dim: int = 100
+    base_channels: int = 64
+    image_channels: int = 3
+
+
+class Generator(nn.Module):
+    """Generator network that maps latent vectors to 64x64 RGB images."""
+
+    def __init__(self, config: DCGANConfig = DCGANConfig()) -> None:
+        super().__init__()
+        self.config = config
+
+        self.project = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "linear",
+                        nn.Linear(
+                            config.latent_dim,
+                            4 * 4 * config.base_channels * 8,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn", nn.BatchNorm1d(config.base_channels * 8 * 4 * 4)),
+                    ("relu", nn.ReLU(True)),
+                ]
+            )
+        )
+
+        self.upsamplers = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "deconv1",
+                        nn.ConvTranspose2d(
+                            config.base_channels * 8,
+                            config.base_channels * 4,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            output_padding=1,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn1", nn.BatchNorm2d(config.base_channels * 4)),
+                    ("relu1", nn.ReLU(True)),
+                    (
+                        "deconv2",
+                        nn.ConvTranspose2d(
+                            config.base_channels * 4,
+                            config.base_channels * 2,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            output_padding=1,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn2", nn.BatchNorm2d(config.base_channels * 2)),
+                    ("relu2", nn.ReLU(True)),
+                    (
+                        "deconv3",
+                        nn.ConvTranspose2d(
+                            config.base_channels * 2,
+                            config.base_channels,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            output_padding=1,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn3", nn.BatchNorm2d(config.base_channels)),
+                    ("relu3", nn.ReLU(True)),
+                    (
+                        "deconv4",
+                        nn.ConvTranspose2d(
+                            config.base_channels,
+                            config.image_channels,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            output_padding=1,
+                            bias=True,
+                        ),
+                    ),
+                    ("tanh", nn.Tanh()),
+                ]
+            )
+        )
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        if z.dim() != 2 or z.size(1) != self.config.latent_dim:
+            raise ValueError(
+                f"Expected latent vectors of shape (batch, {self.config.latent_dim}), "
+                f"got {tuple(z.shape)}"
+            )
+        x = self.project(z)
+        x = x.view(z.size(0), self.config.base_channels * 8, 4, 4)
+        return self.upsamplers(x)
+
+
+class Discriminator(nn.Module):
+    """Discriminator network that scores 64x64 RGB images."""
+
+    def __init__(self, config: DCGANConfig = DCGANConfig()) -> None:
+        super().__init__()
+        self.config = config
+
+        self.features = nn.Sequential(
+            OrderedDict(
+                [
+                    (
+                        "conv1",
+                        nn.Conv2d(
+                            config.image_channels,
+                            config.base_channels,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            bias=True,
+                        ),
+                    ),
+                    ("lrelu1", nn.LeakyReLU(0.2, inplace=True)),
+                    (
+                        "conv2",
+                        nn.Conv2d(
+                            config.base_channels,
+                            config.base_channels * 2,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn2", nn.BatchNorm2d(config.base_channels * 2)),
+                    ("lrelu2", nn.LeakyReLU(0.2, inplace=True)),
+                    (
+                        "conv3",
+                        nn.Conv2d(
+                            config.base_channels * 2,
+                            config.base_channels * 4,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn3", nn.BatchNorm2d(config.base_channels * 4)),
+                    ("lrelu3", nn.LeakyReLU(0.2, inplace=True)),
+                    (
+                        "conv4",
+                        nn.Conv2d(
+                            config.base_channels * 4,
+                            config.base_channels * 8,
+                            kernel_size=5,
+                            stride=2,
+                            padding=2,
+                            bias=False,
+                        ),
+                    ),
+                    ("bn4", nn.BatchNorm2d(config.base_channels * 8)),
+                    ("lrelu4", nn.LeakyReLU(0.2, inplace=True)),
+                ]
+            )
+        )
+
+        self.head = nn.Linear(config.base_channels * 8 * 4 * 4, 1)
+
+    def forward(self, img: torch.Tensor) -> torch.Tensor:
+        if img.dim() != 4 or img.size(1) != self.config.image_channels:
+            raise ValueError(
+                f"Expected images of shape (batch, {self.config.image_channels}, 64, 64), "
+                f"got {tuple(img.shape)}"
+            )
+        features = self.features(img)
+        logits = self.head(features.view(img.size(0), -1)).view(img.size(0))
+        return logits
+
+
+def weights_init(module: nn.Module) -> None:
+    """Initialize model weights following the original DCGAN recipe."""
+
+    if isinstance(module, (nn.Conv2d, nn.ConvTranspose2d, nn.Linear)):
+        nn.init.normal_(module.weight.data, 0.0, 0.02)
+        if getattr(module, "bias", None) is not None:
+            nn.init.constant_(module.bias.data, 0.0)
+    elif isinstance(module, (nn.BatchNorm1d, nn.BatchNorm2d)):
+        nn.init.normal_(module.weight.data, 1.0, 0.02)
+        nn.init.constant_(module.bias.data, 0.0)
+
+
+__all__ = [
+    "DCGANConfig",
+    "Generator",
+    "Discriminator",
+    "weights_init",
+]

--- a/train_celeba_dcgan_torch.py
+++ b/train_celeba_dcgan_torch.py
@@ -1,0 +1,203 @@
+"""PyTorch training script for the CelebA DCGAN baseline.
+
+This script mirrors the behaviour of :mod:`train_celeba_dcgan` but uses the
+PyTorch models defined in :mod:`models_64x64_torch`.  The defaults are chosen
+so that existing datasets can be reused without additional preprocessing.
+"""
+from __future__ import annotations
+
+import argparse
+import math
+from datetime import datetime
+from pathlib import Path
+from typing import Tuple
+
+import torch
+from PIL import Image
+from torch import nn, optim
+from torch.utils.data import DataLoader, Dataset
+from torchvision import transforms, utils as vutils
+
+from models_64x64_torch import DCGANConfig, Discriminator, Generator, weights_init
+
+
+class ImageFolderFlat(Dataset):
+    """Load images from a directory without requiring class sub-folders."""
+
+    def __init__(self, root: str, extensions: Tuple[str, ...] = (".jpg", ".png"), transform=None) -> None:
+        self.root = Path(root)
+        self.transform = transform
+        self.paths = sorted(
+            path
+            for ext in extensions
+            for path in self.root.glob(f"**/*{ext}")
+            if path.is_file()
+        )
+        if not self.paths:
+            raise RuntimeError(
+                f"No images with extensions {extensions} were found under {self.root}."
+            )
+
+    def __len__(self) -> int:
+        return len(self.paths)
+
+    def __getitem__(self, idx: int) -> torch.Tensor:
+        path = self.paths[idx]
+        with Image.open(path) as img:
+            img = img.convert("RGB")
+        if self.transform is not None:
+            img = self.transform(img)
+        return img
+
+
+def build_dataloader(data_root: str, batch_size: int, workers: int) -> DataLoader:
+    transform = transforms.Compose(
+        [
+            transforms.CenterCrop(108),
+            transforms.Resize(64),
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+        ]
+    )
+    dataset = ImageFolderFlat(data_root, transform=transform)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True, num_workers=workers, pin_memory=True)
+
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() and not args.no_cuda else "cpu")
+    if torch.backends.cudnn.is_available():
+        torch.backends.cudnn.benchmark = True
+
+    loader = build_dataloader(args.data_root, args.batch_size, args.workers)
+    config = DCGANConfig(latent_dim=args.latent_dim, base_channels=args.channels)
+
+    generator = Generator(config).to(device)
+    discriminator = Discriminator(config).to(device)
+
+    generator.apply(weights_init)
+    discriminator.apply(weights_init)
+
+    criterion = nn.BCEWithLogitsLoss()
+    optim_g = optim.Adam(generator.parameters(), lr=args.lr, betas=(0.5, 0.999))
+    optim_d = optim.Adam(discriminator.parameters(), lr=args.lr, betas=(0.5, 0.999))
+
+    fixed_noise = torch.randn(args.sample_grid ** 2, args.latent_dim, device=device)
+
+    global_step = 0
+    for epoch in range(args.epochs):
+        for batch_idx, real in enumerate(loader):
+            real = real.to(device)
+            bsz = real.size(0)
+
+            # --- Train discriminator ---
+            optim_d.zero_grad(set_to_none=True)
+            noise = torch.randn(bsz, args.latent_dim, device=device)
+            fake = generator(noise).detach()
+
+            logits_real = discriminator(real)
+            logits_fake = discriminator(fake)
+
+            labels_real = torch.ones_like(logits_real)
+            labels_fake = torch.zeros_like(logits_fake)
+
+            loss_real = criterion(logits_real, labels_real)
+            loss_fake = criterion(logits_fake, labels_fake)
+            loss_d = (loss_real + loss_fake) * 0.5
+            loss_d.backward()
+            optim_d.step()
+
+            # --- Train generator ---
+            optim_g.zero_grad(set_to_none=True)
+            noise = torch.randn(bsz, args.latent_dim, device=device)
+            fake = generator(noise)
+            logits_fake = discriminator(fake)
+            labels_for_g = torch.ones_like(logits_fake)
+            loss_g = criterion(logits_fake, labels_for_g)
+            loss_g.backward()
+            optim_g.step()
+
+            if global_step % args.log_interval == 0:
+                print(
+                    f"Epoch {epoch + 1:03d}/{args.epochs} | Batch {batch_idx + 1:04d}/{len(loader):04d} "
+                    f"| D loss: {loss_d.item():.4f} | G loss: {loss_g.item():.4f}"
+                )
+
+            if global_step % args.sample_interval == 0:
+                save_samples(generator, fixed_noise, args.sample_dir, args.sample_grid, global_step)
+
+            if global_step % args.checkpoint_interval == 0:
+                save_checkpoint(
+                    generator,
+                    discriminator,
+                    optim_g,
+                    optim_d,
+                    args.checkpoint_dir,
+                    epoch,
+                    global_step,
+                )
+
+            global_step += 1
+
+    print("Training finished.")
+
+
+def save_samples(
+    generator: Generator, noise: torch.Tensor, directory: str, grid_size: int, step: int
+) -> None:
+    directory_path = Path(directory)
+    directory_path.mkdir(parents=True, exist_ok=True)
+    generator.eval()
+    with torch.no_grad():
+        samples = generator(noise).cpu()
+    generator.train()
+    grid = vutils.make_grid(samples, nrow=grid_size, normalize=True, value_range=(-1, 1))
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    out_path = directory_path / f"step_{step:07d}_{timestamp}.png"
+    vutils.save_image(grid, out_path)
+
+
+def save_checkpoint(
+    generator: Generator,
+    discriminator: Discriminator,
+    optim_g: optim.Optimizer,
+    optim_d: optim.Optimizer,
+    directory: str,
+    epoch: int,
+    step: int,
+) -> None:
+    directory_path = Path(directory)
+    directory_path.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "epoch": epoch,
+            "step": step,
+            "generator": generator.state_dict(),
+            "discriminator": discriminator.state_dict(),
+            "optim_g": optim_g.state_dict(),
+            "optim_d": optim_d.state_dict(),
+        },
+        directory_path / f"dcgan_{step:07d}.pt",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PyTorch DCGAN trainer for CelebA")
+    parser.add_argument("--data-root", default="./data/img_align_celeba/img_align_celeba", help="Path to the CelebA image directory.")
+    parser.add_argument("--epochs", type=int, default=50, help="Number of training epochs.")
+    parser.add_argument("--batch-size", type=int, default=64, help="Training batch size.")
+    parser.add_argument("--latent-dim", type=int, default=100, help="Dimension of the latent vector z.")
+    parser.add_argument("--channels", type=int, default=64, help="Base number of convolution channels.")
+    parser.add_argument("--lr", type=float, default=2e-4, help="Learning rate for both optimizers.")
+    parser.add_argument("--workers", type=int, default=4, help="Number of dataloader worker processes.")
+    parser.add_argument("--no-cuda", action="store_true", help="Disable CUDA even if available.")
+    parser.add_argument("--log-interval", type=int, default=50, help="Steps between logging training metrics.")
+    parser.add_argument("--sample-interval", type=int, default=500, help="Steps between writing sample grids.")
+    parser.add_argument("--sample-grid", type=int, default=8, help="Number of images per row/column when saving samples.")
+    parser.add_argument("--checkpoint-interval", type=int, default=1000, help="Steps between writing checkpoints.")
+    parser.add_argument("--sample-dir", default="./sample_images_while_training/celeba_dcgan_torch", help="Directory to store generated samples.")
+    parser.add_argument("--checkpoint-dir", default="./checkpoints/celeba_dcgan_torch", help="Directory to store checkpoints.")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    train(parse_args())


### PR DESCRIPTION
## Summary
- align the PyTorch DCGAN generator and discriminator with the TensorFlow layout to allow weight imports
- add a conversion utility that loads TensorFlow checkpoints and saves matching PyTorch state_dict files
- document how to run the checkpoint converter alongside the existing PyTorch training workflow

## Testing
- python -m py_compile models_64x64_torch.py train_celeba_dcgan_torch.py convert_tf_checkpoint_to_torch.py

------
https://chatgpt.com/codex/tasks/task_e_68da199bb25083299f8ebcee3a091df4